### PR TITLE
feat(orderUpdated): Add support for delivery methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 
 # OS clutter
 .DS_Store
+.idea

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bluebird": "^3.4.6",
     "serialize-error": "^2.1.0",
     "sinon": "^1.17.6",
-    "sphere-node-sdk": "^1.16.2",
+    "sphere-node-sdk": "^1.19.3",
     "sphere-node-utils": "^0.9.1",
     "underscore": "^1.8.3",
     "underscore-mixins": "^0.1.4"

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ A library that helps with updating [orders](https://dev.commercetools.com/http-a
 - lineItems
 - syncInfo
 - returnInfo
+- shippingInfo.deliveries
 
 ## Usage
 

--- a/src/build-order-actions.js
+++ b/src/build-order-actions.js
@@ -1,4 +1,3 @@
-import _ from 'underscore'
 import { OrderSync } from 'sphere-node-sdk'
 
 const buildOrderMethods = {
@@ -118,22 +117,11 @@ const buildOrderMethods = {
       'addParcelToDelivery',
     ]
 
-    /* eslint-disable no-param-reassign */
-    order = _.defaults(order, {
-      shippingInfo: {
-        deliveries: [],
-      },
-    })
-
-    existingOrder = _.defaults(existingOrder, {
-      shippingInfo: {
-        deliveries: [],
-      },
-    })
-    /* eslint-enable no-param-reassign */
+    const modOrder = { shippingInfo: { deliveries: [] }, ...order }
+    const modExistOrder = { shippingInfo: { deliveries: [] }, ...existingOrder }
 
     const payload = sync.config()
-      .buildActions(order, existingOrder)
+      .buildActions(modOrder, modExistOrder)
       .getUpdatePayload()
 
     const actions = (payload && payload.actions) || []

--- a/src/build-order-actions.js
+++ b/src/build-order-actions.js
@@ -1,3 +1,4 @@
+import _ from 'underscore'
 import { OrderSync } from 'sphere-node-sdk'
 
 const buildOrderMethods = {
@@ -102,6 +103,38 @@ const buildOrderMethods = {
     const payload = sync.config()
         .buildActions(order, existingOrder)
         .getUpdatePayload()
+
+    const actions = (payload && payload.actions) || []
+
+    // filter only whitelisted actions
+    return actions
+      .filter(action => enabledActions.indexOf(action.action) >= 0)
+  },
+
+  shippingInfo: (order, existingOrder) => {
+    const sync = new OrderSync()
+    const enabledActions = [
+      'addDelivery',
+      'addParcelToDelivery',
+    ]
+
+    /* eslint-disable no-param-reassign */
+    order = _.defaults(order, {
+      shippingInfo: {
+        deliveries: [],
+      },
+    })
+
+    existingOrder = _.defaults(existingOrder, {
+      shippingInfo: {
+        deliveries: [],
+      },
+    })
+    /* eslint-enable no-param-reassign */
+
+    const payload = sync.config()
+      .buildActions(order, existingOrder)
+      .getUpdatePayload()
 
     const actions = (payload && payload.actions) || []
 

--- a/src/build-order-actions.js
+++ b/src/build-order-actions.js
@@ -119,7 +119,6 @@ const buildOrderMethods = {
 
     const modOrder = { shippingInfo: { deliveries: [] }, ...order }
     const modExistOrder = { shippingInfo: { deliveries: [] }, ...existingOrder }
-
     const payload = sync.config()
       .buildActions(modOrder, modExistOrder)
       .getUpdatePayload()

--- a/src/order-schema.js
+++ b/src/order-schema.js
@@ -86,7 +86,7 @@ module.exports = {
       type: 'string',
     },
     shippingInfo: {
-      type: 'string',
+      type: 'object',
     },
     syncInfo: {
       type: 'array',

--- a/tests/helpers/order-delivery-sample.json
+++ b/tests/helpers/order-delivery-sample.json
@@ -1,0 +1,69 @@
+{
+  "orderNumber": "--order number--",
+  "shippingInfo": {
+    "deliveries": [
+      {
+        "id": "1",
+        "items": [
+          {
+            "id": "--item id--",
+            "quantity": 100
+          }
+        ],
+        "parcels": [
+          {
+            "id": "1",
+            "trackingData": {
+              "trackingId": "123456789",
+              "carrier": "TEST",
+              "provider": "provider 1",
+              "providerTransaction": "provider transaction 1",
+              "isReturn": false
+            },
+            "measurements": {
+              "lengthInMillimeter": 100,
+              "heightInMillimeter": 200,
+              "widthInMillimeter": 200,
+              "weightInGram": 500
+            }
+          }
+        ]
+      },
+      {
+        "id": "--delivery id--",
+        "items": [
+          {
+            "id": "--item id--",
+            "quantity": 1
+          }
+        ],
+        "parcels": [
+          {
+            "id": "222",
+            "trackingData": {
+              "trackingId": "123456789",
+              "carrier": "ppl",
+              "provider": "provider",
+              "providerTransaction": "transaction provider",
+              "isReturn": false
+            },
+            "measurements": {
+              "lengthInMillimeter": 100,
+              "heightInMillimeter": 200,
+              "widthInMillimeter": 200,
+              "weightInGram": 500
+            }
+          },
+          {
+            "id": "--parcel id--",
+            "trackingData": {
+              "trackingId": "447883009643",
+              "carrier": "dhl",
+              "isReturn": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/helpers/shipping-method-sample.json
+++ b/tests/helpers/shipping-method-sample.json
@@ -1,0 +1,10 @@
+{
+  "name": "DHL",
+  "description": "Standard delivery",
+  "zoneRates": [],
+  "isDefault": true,
+  "taxCategory": {
+    "typeId": "tax-category",
+    "id": "id"
+  }
+}

--- a/tests/helpers/tax-category-sample.json
+++ b/tests/helpers/tax-category-sample.json
@@ -1,0 +1,13 @@
+{
+  "name": "tax_default",
+  "rates": [
+    {
+      "name": "DE",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "country": "DE",
+      "id": "abcd",
+      "subRates": []
+    }
+  ]
+}

--- a/tests/unit/orders-update.spec.js
+++ b/tests/unit/orders-update.spec.js
@@ -197,6 +197,9 @@ test(`updateOrder
         total: 1,
         results: [{
           id: 'ageart3raefaetq4raefa',
+          shippingInfo: {
+            deliveries: [],
+          },
         }],
       },
     }),


### PR DESCRIPTION
#### Summary
This PR resolves #14 

#### Description
It adds a support for actions `addDelivery` and `addParcelToDelivery`

#### Reviewers
<!-- The persons assigned to review this PR should mark their item as done when they are happy with this PR to be merged -->

- [ ] Reviewer 1 has approved the PR
- [ ] Reviewer 2 has approved the PR

#### TODO

- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation