### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
 
 before_install:
   - npm install npm -g


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description
- Add of node v8 to CI and remove v4 in orders-update


Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)