### PR TITLE
chore: Drop support for Node < 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 6
-  - 8
+  - 10
+  - 12
 
 before_install:
   - npm install npm -g

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">= 10.0.0"
+  },
   "scripts": {
     "start": "npm run test:watch",
     "test": "cross-env NODE_ENV=test NODE_PATH=./src babel-node node_modules/.bin/tape tests/**/*.spec.js | tap-spec",


### PR DESCRIPTION
#### Drop Support for node less than version 10
1. Updated Node JS version  on package.json
2. Updated Test cases node JS version

Closes #22 